### PR TITLE
Add bottom navigation with photo, profile and chat tabs

### DIFF
--- a/app/(tabs)/_layout.tsx
+++ b/app/(tabs)/_layout.tsx
@@ -13,6 +13,7 @@ export default function TabLayout() {
 
   return (
     <Tabs
+      initialRouteName="photos"
       screenOptions={{
         tabBarActiveTintColor: Colors[colorScheme ?? 'light'].tint,
         headerShown: false,
@@ -27,17 +28,26 @@ export default function TabLayout() {
         }),
       }}>
       <Tabs.Screen
-        name="index"
+        name="photos"
         options={{
-          title: 'Home',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="house.fill" color={color} />,
+          title: 'Photos',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="photo.fill" color={color} />,
         }}
       />
       <Tabs.Screen
-        name="explore"
+        name="profile"
         options={{
-          title: 'Explore',
-          tabBarIcon: ({ color }) => <IconSymbol size={28} name="paperplane.fill" color={color} />,
+          title: 'Profile',
+          tabBarIcon: ({ color }) => <IconSymbol size={28} name="person.fill" color={color} />,
+        }}
+      />
+      <Tabs.Screen
+        name="chat"
+        options={{
+          title: 'Chat',
+          tabBarIcon: ({ color }) => (
+            <IconSymbol size={28} name="bubble.left.and.bubble.right.fill" color={color} />
+          ),
         }}
       />
     </Tabs>

--- a/app/(tabs)/chat.tsx
+++ b/app/(tabs)/chat.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../screens/ChatScreen';

--- a/app/(tabs)/photos.tsx
+++ b/app/(tabs)/photos.tsx
@@ -1,0 +1,1 @@
+export { default } from '../upload';

--- a/app/(tabs)/profile.tsx
+++ b/app/(tabs)/profile.tsx
@@ -1,0 +1,1 @@
+export { default } from '../../screens/ProfileScreen';

--- a/components/ui/IconSymbol.tsx
+++ b/components/ui/IconSymbol.tsx
@@ -18,6 +18,9 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'photo.fill': 'photo',
+  'person.fill': 'person',
+  'bubble.left.and.bubble.right.fill': 'chat',
 } as IconMapping;
 
 /**

--- a/screens/ChatScreen.tsx
+++ b/screens/ChatScreen.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function ChatScreen() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.center}>
+        <Text style={styles.text}>Chat</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  text: { fontSize: 24, fontWeight: '600' },
+});

--- a/screens/ProfileScreen.tsx
+++ b/screens/ProfileScreen.tsx
@@ -1,0 +1,19 @@
+import React from 'react';
+import { View, Text, StyleSheet } from 'react-native';
+import { SafeAreaView } from 'react-native-safe-area-context';
+
+export default function ProfileScreen() {
+  return (
+    <SafeAreaView style={styles.container}>
+      <View style={styles.center}>
+        <Text style={styles.text}>Profile</Text>
+      </View>
+    </SafeAreaView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: { flex: 1 },
+  center: { flex: 1, alignItems: 'center', justifyContent: 'center' },
+  text: { fontSize: 24, fontWeight: '600' },
+});

--- a/screens/SsoScreen.tsx
+++ b/screens/SsoScreen.tsx
@@ -23,7 +23,7 @@ export default function SsoScreen() {
     if (scores) {
       router.replace({ pathname: '/rating', params: { scores, feedback } });
     } else {
-      router.replace('/upload');
+      router.replace('/(tabs)/photos');
     }
   }, [router, scores, feedback]);
 


### PR DESCRIPTION
## Summary
- introduce tab bar with Photos, Profile and Chat screens
- route past SSO to photo upload tab
- map new icons for tab bar use

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689ac2d38414832c8b7fc18ced09dbff